### PR TITLE
[RELEASE BUILD CRASH] Upgrade android sdk from 27 to 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Fix release build

see [Flutter#47122](https://github.com/flutter/flutter/issues/47122)